### PR TITLE
Parser / models / aggregation refactor

### DIFF
--- a/elex/demo/__main__.py
+++ b/elex/demo/__main__.py
@@ -22,11 +22,11 @@ if __name__ == "__main__":
     races, reporting_units, candidate_reporting_units = e.get_units(raw_races)
     candidates, ballot_positions = e.get_uniques(candidate_reporting_units)
 
-    print "Parsed %s races." % len(races)
-    print "Parsed %s candidates." % len(candidates)
-    print "Parsed %s ballot positions." % len(ballot_positions)
-    print "Parsed %s reporting units." % len(reporting_units)
-    print "Parsed %s candidate reporting units." % len(candidate_reporting_units)
+    print "Parse: %s races." % len(races)
+    print "Parse: %s candidates." % len(candidates)
+    print "Parse: %s ballot positions." % len(ballot_positions)
+    print "Parse: %s reporting units." % len(reporting_units)
+    print "Parse: %s candidate reporting units." % len(candidate_reporting_units)
 
     parse_end = datetime.datetime.now()
 
@@ -51,11 +51,11 @@ if __name__ == "__main__":
 
     loader.ELEX_PG_CONNEX.close()
 
-    print "Inserted %s races." % len(races)
-    print "Inserted %s candidates." % len(candidates)
-    print "Inserted %s ballot positions." % len(ballot_positions)
-    print "Inserted %s reporting units." % len(reporting_units)
-    print "Inserted %s candidate reporting units." % len(candidate_reporting_units)
+    print "Insert: %s races." % len(races)
+    print "Insert: %s candidates." % len(candidates)
+    print "Insert: %s ballot positions." % len(ballot_positions)
+    print "Insert: %s reporting units." % len(reporting_units)
+    print "Insert: %s candidate reporting units." % len(candidate_reporting_units)
 
     end = datetime.datetime.now()
 

--- a/elex/demo/__main__.py
+++ b/elex/demo/__main__.py
@@ -13,104 +13,52 @@ if __name__ == "__main__":
     those into the DB using Peewee and psycopg2.
     """
 
-    TABLE_LIST = [
-        postgres.Candidate,
-        postgres.CandidateResult,
-        postgres.Race,
-        postgres.ReportingUnit,
-        postgres.BallotPosition
-    ]
 
     start = datetime.datetime.now()
 
-    candidate_results = []
-    reportingunits = []
-    races = []
-
-    ## FIRST: AGGREGATE VOTE TOTALS
-
     e = api.Election(electiondate='2015-11-03', testresults=False, liveresults=True, is_test=False)
-    for race in e.get_races(omitResults=False, level="ru", test=False):
-        for ru in race.reportingunits:
-            ru.aggregate_vote_count('votecount', 'reportingunit_votecount')
-        race.aggregate_vote_count('reportingunit_votecount', 'race_votecount')
+    raw_races = e.get_races(omitResults=False, level="ru", test=False)
 
-        ## SECOND: AGGREGATE VOTE PCTS.
-        # Need the second loop because we have to go back through now and
-        # calculate percentages with the totals aggregated all the way
-        # down to the candidateresult level.
-        for ru in race.reportingunits:
-            for c in ru.candidates:
-                c.aggregate_pcts(race.race_votecount, ru.reportingunit_votecount)
-                candidate_results.append(c)
+    races, reporting_units, candidate_reporting_units = e.get_units(raw_races)
+    candidates, ballot_positions = e.get_uniques(candidate_reporting_units)
 
-            ru.aggregate_pcts(race.race_votecount)
-            del ru.candidates
-            reportingunits.append(ru)
- 
-        del race.candidates
-        del race.reportingunits
-        races.append(race)
-
-    ## THIRD: FIND CANDIDATES, BALLOT POSITIONS
-    # Separate out unique candidates and ballot positions.
-    unique_candidates = {}
-    unique_ballotpositions = {}
-
-    for c in candidate_results:
-        if c.is_ballot_position:
-            if not unique_ballotpositions.get(c.candidateid, None):
-                unique_ballotpositions[c.candidateid] = {"last": c.last, "candidateid": c.candidateid, "polid": c.polid, "ballotorder": c.ballotorder, "polnum": c.polnum, "seatname": c.seatname, "description": c.description}
-        else:
-            if not unique_candidates.get(c.candidateid, None):
-                unique_candidates[c.candidateid] = {"first": c.first, "last": c.last, "candidateid": c.candidateid, "polid": c.polid, "ballotorder": c.ballotorder, "polnum": c.polnum, "party": c.party}
-
-    candidates = [postgres.Candidate(**v) for v in unique_candidates.values()]
-    ballotpositions = [postgres.BallotPosition(**v) for v in unique_ballotpositions.values()]
-
-    print "Parsed %s candidate results." % len(candidate_results)
+    print "Parsed %s races." % len(races)
     print "Parsed %s candidates." % len(candidates)
-    print "Parsed %s ballot positions." % len(ballotpositions)
-    print "Parsed %s reporting units." % len(reportingunits)
-    print "Parsed %s races.\n" % len(races)
+    print "Parsed %s ballot positions." % len(ballot_positions)
+    print "Parsed %s reporting units." % len(reporting_units)
+    print "Parsed %s candidate reporting units." % len(candidate_reporting_units)
 
     parse_end = datetime.datetime.now()
 
-    # Connect to the database.
-    # Drop and recreate tables, as we're bulk-loading.
+    DB_MAPPING = [
+        (postgres.Candidate, candidates),
+        (postgres.BallotPosition, ballot_positions),
+        (postgres.CandidateReportingUnit, candidate_reporting_units),
+        (postgres.ReportingUnit, reporting_units),
+        (postgres.Race, races)
+    ]
+
+    # # Connect to the database.
+    # # Drop and recreate tables, as we're bulk-loading.
     loader.ELEX_PG_CONNEX.connect()
-    loader.ELEX_PG_CONNEX.drop_tables(TABLE_LIST, safe=True)
-    loader.ELEX_PG_CONNEX.create_tables(TABLE_LIST, safe=True)
+    loader.ELEX_PG_CONNEX.drop_tables([m[0] for m in DB_MAPPING], safe=True)
+    loader.ELEX_PG_CONNEX.create_tables([m[0] for m in DB_MAPPING], safe=True)
 
-    # Do the bulk loads with atomic transactions.
-    with loader.ELEX_PG_CONNEX.atomic():
-        for idx in range(0, len(candidates), 1000):
-            postgres.Candidate.insert_many([c.__dict__['_data'] for c in candidates[idx:idx+1000]]).execute()
+    for obj, obj_list in DB_MAPPING:
+        with loader.ELEX_PG_CONNEX.atomic():
+            for idx in range(0, len(obj_list), 2000):
+                obj.insert_many([o.__dict__ for o in obj_list[idx:idx+2000]]).execute()
 
-    with loader.ELEX_PG_CONNEX.atomic():
-        for idx in range(0, len(ballotpositions), 1000):
-            postgres.BallotPosition.insert_many([c.__dict__['_data'] for c in ballotpositions[idx:idx+1000]]).execute()
+    loader.ELEX_PG_CONNEX.close()
 
-    with loader.ELEX_PG_CONNEX.atomic():
-        for idx in range(0, len(candidate_results), 1000):
-            postgres.CandidateResult.insert_many([c.__dict__ for c in candidate_results[idx:idx+1000]]).execute()
-
-    with loader.ELEX_PG_CONNEX.atomic():
-        for idx in range(0, len(reportingunits), 1000):
-            postgres.ReportingUnit.insert_many([c.__dict__ for c in reportingunits[idx:idx+1000]]).execute()
-
-    with loader.ELEX_PG_CONNEX.atomic():
-        for idx in range(0, len(races), 1000):
-            postgres.Race.insert_many([c.__dict__ for c in races[idx:idx+1000]]).execute()
-
-    print "Inserted %s candidate results." % len(candidate_results)
+    print "Inserted %s races." % len(races)
     print "Inserted %s candidates." % len(candidates)
-    print "Inserted %s ballot positions." % len(ballotpositions)
-    print "Inserted %s reporting units." % len(reportingunits)
-    print "Inserted %s races.\n" % len(races)
+    print "Inserted %s ballot positions." % len(ballot_positions)
+    print "Inserted %s reporting units." % len(reporting_units)
+    print "Inserted %s candidate reporting units." % len(candidate_reporting_units)
 
     end = datetime.datetime.now()
 
     print "Overall: %s seconds." % float(str(end - start).split(':')[-1])
-    print "  Parsing: %s seconds." % float(str(parse_end - start).split(':')[-1])
-    print "  Loading: %s seconds." % float(str(end - parse_end).split(':')[-1])
+    print "Parsing: %s seconds." % float(str(parse_end - start).split(':')[-1])
+    print "Loading: %s seconds." % float(str(end - parse_end).split(':')[-1])

--- a/elex/loader/__init__.py
+++ b/elex/loader/__init__.py
@@ -43,6 +43,7 @@ class CandidateReportingUnitModel(peewee.Model):
     ballotorder = peewee.CharField(null=True)
     polnum = peewee.CharField(null=True)
     votecount = peewee.IntegerField(default=0)
+    votepct = peewee.FloatField(default=0)
     winner = peewee.BooleanField(default=False)
     is_ballot_position = peewee.BooleanField(default=False)
 
@@ -146,6 +147,7 @@ class ReportingUnitModel(peewee.Model):
     precinctsreporting = peewee.IntegerField(default=0)
     precinctstotal = peewee.IntegerField(default=0)
     precinctsreportingpct = peewee.FloatField(default=0.0)
+    votecount = peewee.IntegerField(default=0)
 
 
 class RaceModel(peewee.Model):

--- a/elex/loader/__init__.py
+++ b/elex/loader/__init__.py
@@ -26,7 +26,7 @@ class PostgresModel(peewee.Model):
         database = ELEX_PG_CONNEX
 
 
-class CandidateResultModel(peewee.Model):
+class CandidateReportingUnitModel(peewee.Model):
     """
     Fields but no database connection.
     For flexibility.
@@ -34,14 +34,7 @@ class CandidateResultModel(peewee.Model):
     record in a single reporting unit.
     """
     accept_ap_calls = peewee.BooleanField(default=True)
-    race_id = peewee.IntegerField(null=True)
-    reporting_unit_id = peewee.IntegerField(null=True)
-    candidate_id = peewee.IntegerField(null=True)
-    officeid = peewee.CharField(null=True)
-    officename = peewee.CharField(null=True)
-    racetype = peewee.CharField(null=True)
-    reportingunitid = peewee.CharField(null=True)
-    reportingunitname = peewee.CharField(null=True)
+
     first = peewee.CharField(null=True)
     last = peewee.CharField(null=True)
     party = peewee.CharField(null=True)
@@ -52,91 +45,7 @@ class CandidateResultModel(peewee.Model):
     votecount = peewee.IntegerField(default=0)
     winner = peewee.BooleanField(default=False)
     is_ballot_position = peewee.BooleanField(default=False)
-    raceid = peewee.CharField(null=True)
-    statepostal = peewee.CharField(null=True)
-    statename = peewee.CharField(null=True)
-    seatname = peewee.CharField(null=True)
-    description = peewee.CharField(null=True)
-    reportingunit_votecount = peewee.IntegerField(default=0)
-    reportingunit_votepct = peewee.FloatField(default=0.0)
-    race_votecount = peewee.IntegerField(default=0)
-    race_votepct = peewee.FloatField(default=0.0)
-    uncontested = peewee.BooleanField(default=False)
 
-
-class BallotPositionModel(peewee.Model):
-    """
-    Fields but no database connection.
-    For flexibility.
-    last contains the 'yes/no' field.
-    """
-    clean_name = peewee.CharField(null=True)
-    clean_description = peewee.TextField(null=True)
-    last = peewee.CharField(null=True)
-    candidateid = peewee.CharField(null=True)
-    polid = peewee.CharField(null=True)
-    ballotorder = peewee.CharField(null=True)
-    polnum = peewee.CharField(null=True)
-    description = peewee.CharField(null=True)
-    seatname = peewee.CharField(null=True)
-
-
-class CandidateModel(peewee.Model):
-    """
-    Fields but no database connection.
-    For flexibility.
-    """
-    clean_name = peewee.CharField(null=True)
-    clean_description = peewee.TextField(null=True)
-    first = peewee.CharField(null=True)
-    last = peewee.CharField(null=True)
-    party = peewee.CharField(null=True)
-    candidateid = peewee.CharField(null=True)
-    polid = peewee.CharField(null=True)
-    ballotorder = peewee.CharField(null=True)
-    polnum = peewee.CharField(null=True)
-
-
-class ReportingUnitModel(peewee.Model):
-    """
-    Fields but no database connection.
-    For flexibility.
-    """
-    accept_ap_calls = peewee.BooleanField(default=True)
-    clean_name = peewee.CharField(null=True)
-    clean_description = peewee.TextField(null=True)
-    race_id = peewee.IntegerField(null=True)
-    officeid = peewee.CharField(null=True)
-    officename = peewee.CharField(null=True)
-    racetype = peewee.CharField(null=True)
-    statepostal = peewee.CharField(null=True)
-    statename = peewee.CharField(null=True)
-    level = peewee.CharField(null=True)
-    reportingunitname = peewee.CharField(null=True)
-    reportingunitid = peewee.CharField(null=True)
-    fipscode = peewee.CharField(null=True)
-    lastupdated = peewee.CharField(null=True)
-    lastupdated_parsed = peewee.DateTimeField(null=True)
-    precinctsreporting = peewee.IntegerField(default=0)
-    precinctstotal = peewee.IntegerField(default=0)
-    precinctsreportingpct = peewee.FloatField(default=0.0)
-    raceid = peewee.CharField(null=True)
-    description = peewee.CharField(null=True)
-    seatname = peewee.CharField(null=True)
-    reportingunit_votecount = peewee.IntegerField(default=0)
-    race_votecount = peewee.IntegerField(default=0)
-    race_votepct = peewee.FloatField(default=0.0)
-    uncontested = peewee.BooleanField(default=False)
-
-
-class RaceModel(peewee.Model):
-    """
-    Fields but no database connection.
-    For flexibility.
-    """
-    accept_ap_calls = peewee.BooleanField(default=True)
-    clean_name = peewee.CharField(null=True)
-    clean_description = peewee.TextField(null=True)
     description = peewee.CharField(null=True)
     test = peewee.BooleanField(default=False)
     raceid = peewee.CharField(null=True)
@@ -154,7 +63,117 @@ class RaceModel(peewee.Model):
     lastupdated = peewee.CharField(null=True)
     lastupdated_parsed = peewee.DateTimeField(null=True)
     initialization_data = peewee.BooleanField(default=False)
-    race_votecount = peewee.IntegerField(default=0)
+
+    level = peewee.CharField(null=True)
+    reportingunitname = peewee.CharField(null=True)
+    reportingunitid = peewee.CharField(null=True)
+    fipscode = peewee.CharField(null=True)
+    lastupdated = peewee.CharField(null=True)
+    lastupdated_parsed = peewee.DateTimeField(null=True)
+    precinctsreporting = peewee.IntegerField(default=0)
+    precinctstotal = peewee.IntegerField(default=0)
+    precinctsreportingpct = peewee.FloatField(default=0.0)
+
+
+class BallotPositionModel(peewee.Model):
+    """
+    Fields but no database connection.
+    For flexibility.
+    last contains the 'yes/no' field.
+    """
+    clean_name = peewee.CharField(null=True)
+    clean_description = peewee.TextField(null=True)
+
+    last = peewee.CharField(null=True)
+    candidateid = peewee.CharField(null=True)
+    polid = peewee.CharField(null=True)
+    ballotorder = peewee.CharField(null=True)
+    polnum = peewee.CharField(null=True)
+    description = peewee.CharField(null=True)
+    seatname = peewee.CharField(null=True)
+
+
+class CandidateModel(peewee.Model):
+    """
+    Fields but no database connection.
+    For flexibility.
+    """
+    clean_name = peewee.CharField(null=True)
+    clean_description = peewee.TextField(null=True)
+
+    first = peewee.CharField(null=True)
+    last = peewee.CharField(null=True)
+    party = peewee.CharField(null=True)
+    candidateid = peewee.CharField(null=True)
+    polid = peewee.CharField(null=True)
+    ballotorder = peewee.CharField(null=True)
+    polnum = peewee.CharField(null=True)
+
+
+class ReportingUnitModel(peewee.Model):
+    """
+    Fields but no database connection.
+    For flexibility.
+    """
+    accept_ap_calls = peewee.BooleanField(default=True)
+    clean_name = peewee.CharField(null=True)
+    clean_description = peewee.TextField(null=True)
+
+    description = peewee.CharField(null=True)
+    test = peewee.BooleanField(default=False)
+    raceid = peewee.CharField(null=True)
+    statepostal = peewee.CharField(null=True)
+    statename = peewee.CharField(null=True)
+    racetype = peewee.CharField(null=True)
+    reportingunitid = peewee.CharField(null=True)
+    racetypeid = peewee.CharField(null=True)
+    officeid = peewee.CharField(null=True)
+    officename = peewee.CharField(null=True)
+    party = peewee.CharField(null=True)
+    seatname = peewee.CharField(null=True)
+    seatnum = peewee.CharField(null=True)
+    uncontested = peewee.BooleanField(default=False)
+    lastupdated = peewee.CharField(null=True)
+    lastupdated_parsed = peewee.DateTimeField(null=True)
+    initialization_data = peewee.BooleanField(default=False)
+
+    level = peewee.CharField(null=True)
+    reportingunitname = peewee.CharField(null=True)
+    reportingunitid = peewee.CharField(null=True)
+    fipscode = peewee.CharField(null=True)
+    lastupdated = peewee.CharField(null=True)
+    lastupdated_parsed = peewee.DateTimeField(null=True)
+    precinctsreporting = peewee.IntegerField(default=0)
+    precinctstotal = peewee.IntegerField(default=0)
+    precinctsreportingpct = peewee.FloatField(default=0.0)
+
+
+class RaceModel(peewee.Model):
+    """
+    Fields but no database connection.
+    For flexibility.
+    """
+    accept_ap_calls = peewee.BooleanField(default=True)
+    clean_name = peewee.CharField(null=True)
+    clean_description = peewee.TextField(null=True)
+
+    description = peewee.CharField(null=True)
+    test = peewee.BooleanField(default=False)
+    raceid = peewee.CharField(null=True)
+    statepostal = peewee.CharField(null=True)
+    statename = peewee.CharField(null=True)
+    racetype = peewee.CharField(null=True)
+    reportingunitid = peewee.CharField(null=True)
+    racetypeid = peewee.CharField(null=True)
+    officeid = peewee.CharField(null=True)
+    officename = peewee.CharField(null=True)
+    party = peewee.CharField(null=True)
+    seatname = peewee.CharField(null=True)
+    seatnum = peewee.CharField(null=True)
+    uncontested = peewee.BooleanField(default=False)
+    lastupdated = peewee.CharField(null=True)
+    lastupdated_parsed = peewee.DateTimeField(null=True)
+    initialization_data = peewee.BooleanField(default=False)
 
 
 class ElectionModel(peewee.Model):

--- a/elex/loader/postgres.py
+++ b/elex/loader/postgres.py
@@ -13,7 +13,7 @@ class Candidate(loader.PostgresModel, loader.CandidateModel):
     pass
 
 
-class CandidateResult(loader.PostgresModel, loader.CandidateResultModel):
+class CandidateReportingUnit(loader.PostgresModel, loader.CandidateReportingUnitModel):
     pass
 
 


### PR DESCRIPTION
1. Factor out most of the parsing loops into discrete functions for testing, e.g., `Election.get_units` and `Election.get_uniques`.

2. Refactor models to denormalize all fields from the model directly above in the tree so that hitting the lowest level table, e.g., `CandidateReportingUnit`, gets all data about the `Candidate` or `BallotPosition`, the `ReportingUnit` and the `Race.` Removes future joins for results at the cost of some DB size and repetition.

3. Fixes aggregation by focusing on the `ReportingUnit.level` for vote counts. Still gets percentages on the `CandidateReportingUnit` but only where `ReportingUnit.level` isn't `subunit.`